### PR TITLE
fix: suppress NotOpenSSLWarning and add --version flag to CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@
 
 ### Version History
 
+## [1.0.8] - 2026-04-25
+### Fixed
+- Fixed `NotOpenSSLWarning` by suppressing it before `urllib3` is imported
+### Added
+- Added `--version` / `-v` flag to CLI
+
 ## [1.0.7] - 2026-04-25
 ### Changed
 - Version bump

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 ![GitHub last commit](https://img.shields.io/github/last-commit/ifaakash/ai_commit)
 ![Python](https://img.shields.io/badge/python-3.8+-blue.svg)
 ![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)
-![Latest Release](https://img.shields.io/badge/Release-1.0.7-orange)
+![Latest Release](https://img.shields.io/badge/Release-1.0.8-orange)
 [![PyPi](https://img.shields.io/pypi/v/aicommitter)](https://pypi.org/project/aicommitter/)
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/91b5d92dde4d480b9351b0212fbf725f)](https://app.codacy.com/gh/ifaakash/ai_commit/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 <!--[![Latest Release](https://img.shields.io/badge/Latest-Release-blue?style=for-the-badge)](https://libraries.io/pypi/aicommitter)-->
@@ -48,6 +48,10 @@ For every commit after setup:
 See [CHANGELOG.md](CHANGELOG.md) for a [detailed history](https://libraries.io/pypi/aicommitter) of changes. View on [PyPI](https://pypi.org/project/aicommitter/).
 
 ## Latest Release
+
+**Version 1.0.8** (2026-04-25)
+- Fixed `NotOpenSSLWarning` by suppressing it before `urllib3` is imported
+- Added `--version` / `-v` flag to CLI
 
 **Version 1.0.7** (2026-04-25)
 - Version bump

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "aicommitter"
-version = "1.0.7"
+version = "1.0.8"
 description = "AI powered commit message helper"
 authors = [{name = "ifaakash"}]
 requires-python = ">=3.7.9"

--- a/src/aicommitter/generate_message.py
+++ b/src/aicommitter/generate_message.py
@@ -1,8 +1,12 @@
 import os
 import subprocess
+import warnings
 from enum import Enum
 from subprocess import DEVNULL
 from importlib import resources
+from urllib3.exceptions import NotOpenSSLWarning
+
+warnings.filterwarnings("ignore", category=NotOpenSSLWarning)
 
 import requests
 from requests.adapters import HTTPAdapter
@@ -11,8 +15,6 @@ import typer
 from rich import print
 from rich.panel import Panel
 from dotenv import load_dotenv
-import warnings
-from urllib3.exceptions import NotOpenSSLWarning
 
 load_dotenv(override=True)
 
@@ -20,7 +22,18 @@ app = typer.Typer(
     help="AI Commit Message Generator. Reads staged Git diff and suggests a message"
 )
 
-warnings.filterwarnings("ignore", category=NotOpenSSLWarning)
+def _version_callback(value: bool):
+    if value:
+        typer.echo("aicommitter 1.0.8")
+        raise typer.Exit()
+
+@app.callback()
+def _main(
+    version: bool = typer.Option(
+        None, "--version", "-v", callback=_version_callback, is_eager=True, help="Show version and exit."
+    )
+):
+    pass
 
 SESSION = requests.Session()
 retries = Retry(


### PR DESCRIPTION
- Suppress the `NotOpenSSLWarning` by filtering it before `urllib3` is imported
- Add `--version` / `-v` flag to the CLI that displays the application version
- Bump version to 1.0.8